### PR TITLE
Load data segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.class
 bin/*
 build/*
+dist/*
 !/.gitignore

--- a/src/main/java/wasm/format/Leb128.java
+++ b/src/main/java/wasm/format/Leb128.java
@@ -22,8 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import com.googlecode.d2j.DexException;
-
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.StructConverter;
 import ghidra.program.model.data.ArrayDataType;

--- a/src/main/java/wasm/format/sections/WasmDataSection.java
+++ b/src/main/java/wasm/format/sections/WasmDataSection.java
@@ -2,6 +2,7 @@ package wasm.format.sections;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import ghidra.app.util.bin.BinaryReader;
@@ -25,6 +26,10 @@ public class WasmDataSection implements WasmPayload {
 			dataSegments.add(new WasmDataSegment(reader));
 		}
 
+	}
+
+	public List<WasmDataSegment> getSegments() {
+		return Collections.unmodifiableList(dataSegments);
 	}
 
 	@Override

--- a/src/main/java/wasm/format/sections/structures/WasmDataSegment.java
+++ b/src/main/java/wasm/format/sections/structures/WasmDataSegment.java
@@ -8,21 +8,69 @@ import ghidra.program.model.data.ArrayDataType;
 import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.Structure;
 import ghidra.program.model.data.StructureDataType;
+import ghidra.util.Msg;
 import ghidra.util.exception.DuplicateNameException;
 import wasm.format.Leb128;
 
 public class WasmDataSegment implements StructConverter {
 
 	private Leb128 index;
-	private int offset;
+	private Leb128 offset;
+	private long fileOffset;
 	private Leb128 size;
 	private byte[] data;
 
 	public WasmDataSegment(BinaryReader reader) throws IOException {
 		index = new Leb128(reader);
-		offset = reader.readNextInt();
+		byte offsetOpcode = reader.readNextByte();
+		/* Offset expression is an expr, which must be a constant expression evaluating to an i32.
+		   For this datatype, there are only two possibilities: i32.const (0x41) or global.get (0x23). */
+		if(offsetOpcode == 0x41) {
+			/* i32.const */
+			offset = new Leb128(reader);
+			byte endByte = reader.readNextByte();
+			if(endByte != 0x0b) {
+				Msg.warn(this, "Data segment at file offset " + reader.getPointerIndex() + " does not look normal!");
+			}
+		} else if(offsetOpcode == 0x23) {
+			/* global.get: offset is left as null */
+			// skip globalidx
+			new Leb128(reader);
+			byte endByte = reader.readNextByte();
+			if(endByte != 0x0b) {
+				Msg.warn(this, "Data segment at file offset " + reader.getPointerIndex() + " does not look normal!");
+			}
+		} else {
+			Msg.warn(this, "Unhandled data segment offset: opcode " + offsetOpcode + " at file offset " + reader.getPointerIndex());
+			while(true) {
+				byte endByte = reader.readNextByte();
+				if(endByte == 0x0b)
+					break;
+			}
+		}
 		size = new Leb128(reader);
+		fileOffset = reader.getPointerIndex();
 		data = reader.readNextByteArray((int)size.getValue());
+	}
+
+	public long getIndex() {
+		return index.getValue();
+	}
+
+	public long getFileOffset() {
+		return fileOffset;
+	}
+
+	public long getOffset() {
+		return (offset == null) ? -1 : offset.getValue();
+	}
+
+	public long getSize() {
+		return size.getValue();
+	}
+
+	public byte[] getData() {
+		return data;
 	}
 
 	@Override


### PR DESCRIPTION
This enables proper analysis of memory references, etc. The code for loading the
offset expression is hacky, and in a future commit I'll refactor it to use a
reusable expression parser (so we can eventually handle globals, element tables,
and other features).