### PR TITLE
Fix call stack pops and push

### DIFF
--- a/src/main/java/wasm/pcodeInject/PcodeOpEmitter.java
+++ b/src/main/java/wasm/pcodeInject/PcodeOpEmitter.java
@@ -306,8 +306,6 @@ public class PcodeOpEmitter {
 		for(int i = 0; i < nlocals; i++) {
 			emitMov64("l" + i, "tmp" + i);
 		}
-		
-		emitMov32("SP", "tmpSP");
 	}
 	
 	public void emitRestoreLocals(int nlocals) {
@@ -341,6 +339,8 @@ public class PcodeOpEmitter {
 		
 		//pop parameters from the stack into local registers
 		emitPopParams(numParams);
+		
+		emitMov32("SP", "tmpSP");
 		
 		//do the call
 		emitCall(target.getAddr());


### PR DESCRIPTION
There was an issue in the injected pcode for calls:
`SP` was save before parameter pops and restored before pushing the result value. Parameters where never "consumed" from the stack which was simply growing with each return.

I moved the SP backup to after parameter pops to correct this behavior. This fixed the stack alignment issue and `in_SP`statements in the decompilation. 